### PR TITLE
Allow 'SORT' to be passed as a valid `KeyType` for table creation

### DIFF
--- a/validations/createTable.js
+++ b/validations/createTable.js
@@ -57,7 +57,7 @@ exports.types = {
         KeyType: {
           type: 'String',
           notNull: true,
-          enum: ['HASH', 'RANGE'],
+          enum: ['HASH', 'RANGE', 'SORT'],
         },
       },
     },
@@ -202,6 +202,10 @@ exports.custom = function(data) {
 
   if (keys.length > defns.length)
     return 'Invalid KeySchema: Some index key attribute have no definition'
+  
+  if (data.KeySchema[1].KeyType === 'SORT') {
+      data.KeySchema[1].KeyType = 'RANGE';
+  }
 
   if (keys.some(function(key) { return !~defns.indexOf(key) }))
     return 'One or more parameter values were invalid: Some index key attributes are not defined in ' +
@@ -325,4 +329,3 @@ exports.custom = function(data) {
       return 'One or more parameter values were invalid: GlobalSecondaryIndex count exceeds the per-table limit of 20'
   }
 }
-


### PR DESCRIPTION
Change allows `'SORT'` to be specified as a valid value for `KeyType` when creating a table. None of the current table creation _behavior_ is altered however, `'SORT'` is simply internally re-mapped to `'RANGE'` so that table creations will not fail. This may or may not be "correct", but it does appear to work with no noticeable issues in my local testing.